### PR TITLE
Fix ADFS filename encoding, directory listing performance, and critical safety bugs

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -1452,7 +1452,7 @@ int ras_rpc_handle(const unsigned char *buf, size_t len, const char *addr,
         // Only rename files, not directories (directories don't need ,xxx
         // suffix)
         if (h->path[0] && h->type == RAS_HANDLE_FILE) {
-          char new_path[512];
+          char new_path[1024];
           ras_append_type_suffix(h->path, new_ftype, new_path,
                                  sizeof(new_path));
           if (strcmp(h->path, new_path) != 0) {
@@ -1485,8 +1485,8 @@ int ras_rpc_handle(const unsigned char *buf, size_t len, const char *addr,
               int new_fd = open(new_path, flags);
               if (new_fd >= 0) {
                 h->fd = new_fd;
-                strncpy(h->path, new_path, sizeof(h->path) - 1);
-                h->path[sizeof(h->path) - 1] = '\0';
+                char *np = realloc(h->path, strlen(new_path) + 1);
+                if (np) { h->path = np; strcpy(h->path, new_path); }
                 // Update open_flags to reflect the new state (Text/Binary)
                 h->open_flags = flags;
 
@@ -1511,8 +1511,8 @@ int ras_rpc_handle(const unsigned char *buf, size_t len, const char *addr,
             // POSIX - just rename
             if (rename(h->path, new_path) == 0) {
               // Update handle's stored path
-              strncpy(h->path, new_path, sizeof(h->path) - 1);
-              h->path[sizeof(h->path) - 1] = '\0';
+              char *np = realloc(h->path, strlen(new_path) + 1);
+              if (np) { h->path = np; strcpy(h->path, new_path); }
               ras_log(RAS_LOG_DEBUG, "RSETINFO: renamed to '%s'", new_path);
             } else {
               ras_log(RAS_LOG_ERROR, "RSETINFO: rename failed '%s' -> '%s': %s",

--- a/src/ops.c
+++ b/src/ops.c
@@ -13,7 +13,6 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
@@ -483,21 +482,6 @@ static void send_r_pkt(ras_net *net, const unsigned char *rid, const void *data,
   ras_net_sendto(net->rpc, &pkt, 4 + dlen, addr, port);
 }
 
-static void send_d_pkt(ras_net *net, const unsigned char *rid, const void *data,
-                       size_t dlen, const char *addr, unsigned short port) {
-  unsigned char header[4] = {'D', rid[0], rid[1], rid[2]};
-  struct {
-    unsigned char h[4];
-    unsigned char p[2048];
-  } pkt;
-  if (dlen > sizeof(pkt.p))
-    dlen = sizeof(pkt.p);
-  memcpy(pkt.h, header, 4);
-  if (data && dlen)
-    memcpy(pkt.p, data, dlen);
-  ras_net_sendto(net->rpc, &pkt, 4 + dlen, addr, port);
-}
-
 // Send an unsolicited F packet (e.g., RDEADHANDLES broadcast)
 static void send_f_pkt(ras_net *net, uint32_t code, const void *data,
                        uint16_t dlen, const char *addr,
@@ -553,21 +537,6 @@ static void send_d_pkt_with_offset(ras_net *net, const unsigned char *rid,
     memcpy(pkt.p, data, dlen);
 
   ras_net_sendto(net->rpc, &pkt, 8 + dlen, addr, port);
-}
-
-static void send_s_pkt(ras_net *net, const unsigned char *rid, const void *data,
-                       size_t dlen, const char *addr, unsigned short port) {
-  unsigned char header[4] = {'S', rid[0], rid[1], rid[2]};
-  struct {
-    unsigned char h[4];
-    unsigned char p[2048];
-  } pkt;
-  if (dlen > sizeof(pkt.p))
-    dlen = sizeof(pkt.p);
-  memcpy(pkt.h, header, 4);
-  if (data && dlen)
-    memcpy(pkt.p, data, dlen);
-  ras_net_sendto(net->rpc, &pkt, 4 + dlen, addr, port);
 }
 
 // Build FileDesc (20 bytes): load(4), exec(4), length(4), attrs(4),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Filename encoding** (`src/names.c` / `names.h`): New bidirectional `%XX` percent-encoding layer replaces the old minimal translation. All NTFS-forbidden characters (`<>:"|?*\`), control characters, and the `/`↔`.` / space↔NBSP mappings are now handled losslessly. Fixes issues #2 and #3.
- **RSETINFO path corruption** (`src/ops.c`): `sizeof(h->path)` on a `char *` returns the pointer width (8 bytes), not the buffer size — silently truncating the stored path to 7 chars after a filetype rename. Fixed with `realloc` before copying. Fixes issues #1 and #8.
- **Directory listing cache** (`src/ops.c`, `src/handle.c`/`handle.h`): Directory entries are now read and sorted once at `ROPENDIR` and cached on the handle. `RREADDIR` pages slice the sorted array in O(1) instead of re-walking the directory from index 0 each time (was O(N²) — ~270 round-trips for a 10,000-entry folder).
- **Safety fixes** (`src/ops.c`): Guard `RZERO` offset+length against `uint32_t` overflow; cap `>4 GB` file sizes at `0xFFFFFFFF` instead of silently wrapping; use `lstat` in directory enumeration to avoid following symlinks outside the share; fix NULL dereference in `RCREATE` when filename has no path separator; bump all path buffers 512→1024 bytes for worst-case `%XX` expansion.
- **Dead code removed** (`src/ops.c`): `send_d_pkt()`, `send_s_pkt()`, and an unused `#include <ctype.h>`.
- **Unit tests** (`tests/test_names.c`): Full encode/decode/round-trip test suite registered with `ctest`.

## Test plan

- [ ] `cmake --build build && ctest --test-dir build` — all tests pass
- [ ] Mount share from RISC OS emulator; create files named `test<>file`, `weird:name`, `pipe|name`, `comma,FFF`, `percent%test`, `space file` — verify each lists, reads back, and round-trips correctly
- [ ] Create a 10,000-entry directory; confirm listing completes in seconds (not minutes)
- [ ] Set a filetype on an open file via `RSETINFO`; verify the `,xxx` suffix appears on the host and the file remains accessible after

https://claude.ai/code/session_0156NHLRiRsjX5Wo3GNixHn7
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0156NHLRiRsjX5Wo3GNixHn7)_