### PR TITLE
Codebase review fixes: server security/correctness + admin UI polish

### DIFF
--- a/admin/src/ConfigIO.cpp
+++ b/admin/src/ConfigIO.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <algorithm>
 #include <cctype>
+#include <cstdio>
 
 // Trim whitespace from string
 static std::string Trim(const std::string& str) {
@@ -94,7 +95,7 @@ bool RasConfig::Load(const std::string& path, std::string& error) {
             if (key == "log_level") {
                 m_server.log_level = value;
             } else if (key == "broadcast_interval") {
-                m_server.broadcast_interval = std::stoi(value);
+                try { m_server.broadcast_interval = std::stoi(value); } catch (...) { m_server.broadcast_interval = 3; }
             } else if (key == "access_plus") {
                 m_server.access_plus = (ToLower(value) == "true" || value == "1");
             } else if (key == "bind_ip") {
@@ -118,7 +119,7 @@ bool RasConfig::Load(const std::string& path, std::string& error) {
             } else if (key == "description") {
                 currentPrinter->description = value;
             } else if (key == "poll_interval") {
-                currentPrinter->poll_interval = std::stoi(value);
+                try { currentPrinter->poll_interval = std::stoi(value); } catch (...) { currentPrinter->poll_interval = 5; }
             } else if (key == "command") {
                 currentPrinter->command = value;
             }
@@ -140,63 +141,83 @@ bool RasConfig::Load(const std::string& path, std::string& error) {
 }
 
 bool RasConfig::Save(const std::string& path, std::string& error) {
-    std::ofstream file(path);
-    if (!file.is_open()) {
-        error = "Cannot write to file: " + path;
+    std::string tmpPath = path + ".tmp";
+    {
+        std::ofstream file(tmpPath);
+        if (!file.is_open()) {
+            error = "Cannot write to file: " + tmpPath;
+            return false;
+        }
+
+        file << "# Access/ShareFS Server Configuration\n\n";
+
+        // Server section
+        file << "[server]\n";
+        file << "log_level = " << m_server.log_level << "\n";
+        file << "broadcast_interval = " << m_server.broadcast_interval << "\n";
+        file << "access_plus = " << (m_server.access_plus ? "true" : "false") << "\n";
+        if (!m_server.bind_ip.empty()) {
+            file << "bind_ip = " << m_server.bind_ip << "\n";
+        }
+        file << "\n";
+
+        // Shares
+        for (const auto& share : m_shares) {
+            file << "[share:" << share.name << "]\n";
+            file << "path = " << share.path << "\n";
+            if (share.attributes) {
+                file << "attributes = " << AttrsToString(share.attributes) << "\n";
+            }
+            if (!share.password.empty()) {
+                file << "password = " << share.password << "\n";
+            }
+            if (!share.default_type.empty()) {
+                file << "default_filetype = " << share.default_type << "\n";
+            }
+            file << "\n";
+        }
+
+        // Printers
+        for (const auto& printer : m_printers) {
+            file << "[printer:" << printer.name << "]\n";
+            if (!printer.path.empty())
+                file << "path = " << printer.path << "\n";
+            if (!printer.definition.empty())
+                file << "definition = " << printer.definition << "\n";
+            if (!printer.description.empty())
+                file << "description = " << printer.description << "\n";
+            file << "poll_interval = " << printer.poll_interval << "\n";
+            if (!printer.command.empty())
+                file << "command = " << printer.command << "\n";
+            file << "\n";
+        }
+
+        // MIME map
+        if (!m_mimemap.empty()) {
+            file << "[mimemap]\n";
+            for (const auto& entry : m_mimemap) {
+                file << entry.ext << " = " << entry.filetype << "\n";
+            }
+        }
+
+        file.flush();
+        if (file.fail()) {
+            error = "Write error on file: " + tmpPath;
+            std::remove(tmpPath.c_str());
+            return false;
+        }
+    }
+
+    // Atomic replace; on Windows the destination must not exist first
+#ifdef _WIN32
+    std::remove(path.c_str());
+#endif
+    if (std::rename(tmpPath.c_str(), path.c_str()) != 0) {
+        error = "Failed to replace config file: " + path;
+        std::remove(tmpPath.c_str());
         return false;
     }
-    
-    file << "# Access/ShareFS Server Configuration\n\n";
-    
-    // Server section
-    file << "[server]\n";
-    file << "log_level = " << m_server.log_level << "\n";
-    file << "broadcast_interval = " << m_server.broadcast_interval << "\n";
-    file << "access_plus = " << (m_server.access_plus ? "true" : "false") << "\n";
-    if (!m_server.bind_ip.empty()) {
-        file << "bind_ip = " << m_server.bind_ip << "\n";
-    }
-    file << "\n";
-    
-    // Shares
-    for (const auto& share : m_shares) {
-        file << "[share:" << share.name << "]\n";
-        file << "path = " << share.path << "\n";
-        if (share.attributes) {
-            file << "attributes = " << AttrsToString(share.attributes) << "\n";
-        }
-        if (!share.password.empty()) {
-            file << "password = " << share.password << "\n";
-        }
-        if (!share.default_type.empty()) {
-            file << "default_filetype = " << share.default_type << "\n";
-        }
-        file << "\n";
-    }
-    
-    // Printers
-    for (const auto& printer : m_printers) {
-        file << "[printer:" << printer.name << "]\n";
-        if (!printer.path.empty())
-            file << "path = " << printer.path << "\n";
-        if (!printer.definition.empty())
-            file << "definition = " << printer.definition << "\n";
-        if (!printer.description.empty())
-            file << "description = " << printer.description << "\n";
-        file << "poll_interval = " << printer.poll_interval << "\n";
-        if (!printer.command.empty())
-            file << "command = " << printer.command << "\n";
-        file << "\n";
-    }
-    
-    // MIME map
-    if (!m_mimemap.empty()) {
-        file << "[mimemap]\n";
-        for (const auto& entry : m_mimemap) {
-            file << entry.ext << " = " << entry.filetype << "\n";
-        }
-    }
-    
+
     return true;
 }
 
@@ -205,6 +226,7 @@ std::string RasConfig::AttrsToString(uint32_t attrs) {
     if (attrs & RAS_ATTR_PROTECTED) parts.push_back("protected");
     if (attrs & RAS_ATTR_READONLY) parts.push_back("readonly");
     if (attrs & RAS_ATTR_HIDDEN) parts.push_back("hidden");
+    if (attrs & RAS_ATTR_SUBDIR) parts.push_back("subdir");
     if (attrs & RAS_ATTR_CDROM) parts.push_back("cdrom");
     
     std::string result;
@@ -222,6 +244,7 @@ uint32_t RasConfig::StringToAttrs(const std::string& str) {
     if (lower.find("protected") != std::string::npos) attrs |= RAS_ATTR_PROTECTED;
     if (lower.find("readonly") != std::string::npos) attrs |= RAS_ATTR_READONLY;
     if (lower.find("hidden") != std::string::npos) attrs |= RAS_ATTR_HIDDEN;
+    if (lower.find("subdir") != std::string::npos) attrs |= RAS_ATTR_SUBDIR;
     if (lower.find("cdrom") != std::string::npos) attrs |= RAS_ATTR_CDROM;
     
     return attrs;

--- a/admin/src/ControlPanel.cpp
+++ b/admin/src/ControlPanel.cpp
@@ -81,13 +81,17 @@ wxBEGIN_EVENT_TABLE(ControlPanel, wxPanel)
 
   configGrid->Add(new wxStaticText(this, wxID_ANY, "Config File:"), 0,
                   wxALIGN_CENTER_VERTICAL);
-  m_configPath = new wxTextCtrl(this, wxID_ANY,
+  {
+    wxString defaultConfig;
 #ifdef __WXMSW__
-                                "C:/AccessServer/access.conf"
+    wxString pd;
+    if (!wxGetEnv("ProgramData", &pd) || pd.empty()) pd = "C:";
+    defaultConfig = pd + "\\AccessServer\\access.conf";
 #else
-                                "access.conf"
+    defaultConfig = "/etc/riscos-access-server/access.conf";
 #endif
-  );
+    m_configPath = new wxTextCtrl(this, wxID_ANY, defaultConfig);
+  }
   configGrid->Add(m_configPath, 1, wxEXPAND);
   wxButton *browseBtn = new wxButton(this, ID_BROWSE_CONFIG, "Browse...");
   configGrid->Add(browseBtn, 0);
@@ -189,6 +193,11 @@ void ControlPanel::UpdateStatus() {
 }
 
 void ControlPanel::AppendLog(const wxString &text) {
+  // Trim oldest lines when the log grows too large
+  if (m_logView->GetNumberOfLines() > 5000) {
+    long trimPos = m_logView->XYToPosition(0, 1000);
+    if (trimPos > 0) m_logView->Remove(0, trimPos);
+  }
   m_logView->AppendText(text);
   m_logView->ShowPosition(m_logView->GetLastPosition());
 }
@@ -283,7 +292,7 @@ bool ControlPanel::StartWindowsService() {
 
   bool success = false;
   if (StartService(service, 0, NULL) || GetLastError() == ERROR_SERVICE_ALREADY_RUNNING) {
-    // Poll for running state
+    // Poll for running state, yielding to keep the UI responsive
     SERVICE_STATUS status;
     for (int i = 0; i < 50; ++i) { // up to ~10s
       if (QueryServiceStatus(service, &status) &&
@@ -291,6 +300,7 @@ bool ControlPanel::StartWindowsService() {
         success = true;
         break;
       }
+      wxSafeYield();
       Sleep(200);
     }
   }
@@ -317,13 +327,14 @@ bool ControlPanel::StopWindowsService() {
 
   if (ControlService(service, SERVICE_CONTROL_STOP, &status) ||
       GetLastError() == ERROR_SERVICE_NOT_ACTIVE) {
-    // Poll for stopped state
+    // Poll for stopped state, yielding to keep the UI responsive
     for (int i = 0; i < 50; ++i) { // up to ~10s
       if (QueryServiceStatus(service, &status) &&
           status.dwCurrentState == SERVICE_STOPPED) {
         success = true;
         break;
       }
+      wxSafeYield();
       Sleep(200);
     }
   }
@@ -361,6 +372,11 @@ void ControlPanel::OnStart(wxCommandEvent &event) {
   if (wxExecute("systemctl list-unit-files riscos-access-server.service",
                 wxEXEC_SYNC | wxEXEC_NOEVENTS) == 0) {
     AppendLog("[ADMIN] Attempting to start system service...\n");
+    wxString display, waylandDisplay;
+    if ((!wxGetEnv("DISPLAY", &display) || display.empty()) &&
+        (!wxGetEnv("WAYLAND_DISPLAY", &waylandDisplay) || waylandDisplay.empty())) {
+      AppendLog("[WARN] No graphical display detected; pkexec elevation may fail.\n");
+    }
     long ret =
         wxExecute("pkexec systemctl start riscos-access-server", wxEXEC_SYNC);
     if (ret == 0 || CheckSystemdStatus()) {
@@ -380,20 +396,27 @@ void ControlPanel::OnStart(wxCommandEvent &event) {
     return;
   }
 
-  // Find the access binary - look relative to this executable
+  // Find the access server binary; search common locations in priority order
   wxFileName exePath(wxStandardPaths::Get().GetExecutablePath());
-  wxString accessPath = exePath.GetPath() + wxFileName::GetPathSeparator() +
-                        ".." + wxFileName::GetPathSeparator() + "src" +
-                        wxFileName::GetPathSeparator() + "access";
+  wxString exeDir = exePath.GetPath();
+  wxString sep = wxFileName::GetPathSeparator();
 
-  // If that doesn't exist, try same directory
-  if (!wxFileExists(accessPath)) {
-    accessPath = exePath.GetPath() + wxFileName::GetPathSeparator() + "access";
-  }
+  wxArrayString candidates;
+  candidates.Add(exeDir + sep + ".." + sep + "src" + sep + "access");
+  candidates.Add(exeDir + sep + "access");
+#ifndef _WIN32
+  candidates.Add("/usr/local/bin/access");
+  candidates.Add("/usr/bin/access");
+#else
+  candidates.Add("C:\\AccessServer\\access.exe");
+#endif
 
-  // If still not found, try just "access" in PATH
-  if (!wxFileExists(accessPath)) {
-    accessPath = "access";
+  wxString accessPath = "access"; // fallback: search PATH
+  for (size_t i = 0; i < candidates.GetCount(); ++i) {
+    if (wxFileExists(candidates[i])) {
+      accessPath = candidates[i];
+      break;
+    }
   }
 
   // Build command
@@ -517,8 +540,7 @@ void ControlPanel::RestartServer() {
 #ifdef __WXGTK__
     wxExecute("pkexec systemctl restart riscos-access-server", wxEXEC_SYNC);
 #endif
-    wxMilliSleep(1000); // Wait for service to restart
-    UpdateStatus();
+    UpdateStatus(); // timer will confirm state shortly
   } else {
     StopServer();
     wxMilliSleep(500);

--- a/admin/src/MainFrame.cpp
+++ b/admin/src/MainFrame.cpp
@@ -7,13 +7,16 @@
 #include "MimePanel.h"
 #include "ControlPanel.h"
 #include <wx/filename.h>
+#include <wx/hyperlink.h>
 #include <wx/msgdlg.h>
 
 wxBEGIN_EVENT_TABLE(MainFrame, wxFrame)
+    EVT_MENU(ID_SAVE, MainFrame::OnSave)
     EVT_MENU(ID_APPLY, MainFrame::OnApply)
     EVT_MENU(ID_REVERT, MainFrame::OnRevert)
     EVT_MENU(wxID_EXIT, MainFrame::OnExit)
     EVT_MENU(wxID_ABOUT, MainFrame::OnAbout)
+    EVT_BUTTON(ID_SAVE, MainFrame::OnSave)
     EVT_BUTTON(ID_APPLY, MainFrame::OnApply)
     EVT_BUTTON(ID_REVERT, MainFrame::OnRevert)
     EVT_CLOSE(MainFrame::OnClose)
@@ -54,7 +57,11 @@ MainFrame::MainFrame(const wxString& title)
     m_revertBtn = new wxButton(buttonBar, ID_REVERT, "Revert Changes");
     m_revertBtn->Disable();
     buttonSizer->Add(m_revertBtn, 0, wxALL, 8);
-    
+
+    m_saveBtn = new wxButton(buttonBar, ID_SAVE, "Save");
+    m_saveBtn->Disable();
+    buttonSizer->Add(m_saveBtn, 0, wxALL, 8);
+
     m_applyBtn = new wxButton(buttonBar, ID_APPLY, "Apply && Restart");
     m_applyBtn->Disable();
     buttonSizer->Add(m_applyBtn, 0, wxALL, 8);
@@ -68,7 +75,8 @@ MainFrame::MainFrame(const wxString& title)
 
 void MainFrame::CreateMenuBar() {
     wxMenu* fileMenu = new wxMenu;
-    fileMenu->Append(ID_APPLY, "&Apply && Restart\tCtrl+S", "Save configuration and restart server");
+    fileMenu->Append(ID_SAVE, "&Save\tCtrl+S", "Save configuration");
+    fileMenu->Append(ID_APPLY, "&Apply && Restart\tCtrl+Shift+R", "Save configuration and restart server");
     fileMenu->Append(ID_REVERT, "&Revert Changes", "Discard unsaved changes");
     fileMenu->AppendSeparator();
     fileMenu->Append(wxID_EXIT, "E&xit\tAlt+F4", "Exit application");
@@ -103,6 +111,7 @@ void MainFrame::UpdateTitle() {
 void MainFrame::SetModified(bool modified) {
     if (m_modified != modified) {
         m_modified = modified;
+        m_saveBtn->Enable(modified);
         m_applyBtn->Enable(modified);
         m_revertBtn->Enable(modified);
         UpdateTitle();
@@ -114,6 +123,7 @@ void MainFrame::LoadConfig(const std::string& path) {
     if (m_config.Load(path, error)) {
         m_configPath = path;
         m_modified = false;
+        m_saveBtn->Disable();
         m_applyBtn->Disable();
         m_revertBtn->Disable();
         UpdateTitle();
@@ -135,10 +145,11 @@ void MainFrame::SaveConfig() {
     if (m_configPath.empty()) {
         m_configPath = "access.conf";
     }
-    
+
     std::string error;
     if (m_config.Save(m_configPath, error)) {
         m_modified = false;
+        m_saveBtn->Disable();
         m_applyBtn->Disable();
         m_revertBtn->Disable();
         UpdateTitle();
@@ -155,11 +166,14 @@ void MainFrame::RevertConfig() {
     }
 }
 
+void MainFrame::OnSave(wxCommandEvent& event) {
+    wxUnusedVar(event);
+    SaveConfig();
+}
+
 void MainFrame::OnApply(wxCommandEvent& event) {
     wxUnusedVar(event);
     SaveConfig();
-    
-    // Restart the server with new config
     m_controlPanel->RestartServer();
     SetStatusText("Configuration saved and server restarted");
 }
@@ -197,11 +211,31 @@ void MainFrame::OnClose(wxCloseEvent& event) {
 
 void MainFrame::OnAbout(wxCommandEvent& event) {
     wxUnusedVar(event);
-    wxMessageBox(wxT("Access/ShareFS Server Admin\n\n")
-                 wxT("Administration and control utility for\n")
-                 wxT("the Access/ShareFS server.\n\n")
-                 wxT("Copyright © Andrew Timmins, 2025.\n\n")
-                 wxT("Licensed under the GNU General Public License v3.0\n")
-                 wxT("https://www.gnu.org/licenses/gpl-3.0.html"),
-                 wxT("About"), wxOK | wxICON_INFORMATION);
+
+    wxDialog dlg(this, wxID_ANY, "About Access/ShareFS Admin",
+                 wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE);
+
+    wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
+
+    sizer->Add(new wxStaticText(&dlg, wxID_ANY,
+        "Access/ShareFS Server Admin\n\n"
+        "Administration and control utility for\n"
+        "the Access/ShareFS server.\n\n"
+        "Copyright \xC2\xA9 Andrew Timmins, 2025."),
+        0, wxALL, 15);
+
+    wxBoxSizer* licRow = new wxBoxSizer(wxHORIZONTAL);
+    licRow->Add(new wxStaticText(&dlg, wxID_ANY, "Licensed under the "),
+                0, wxALIGN_CENTRE_VERTICAL);
+    licRow->Add(new wxHyperlinkCtrl(&dlg, wxID_ANY,
+        "GNU General Public License v3.0",
+        "https://www.gnu.org/licenses/gpl-3.0.html"),
+        0, wxALIGN_CENTRE_VERTICAL);
+    sizer->Add(licRow, 0, wxLEFT | wxRIGHT | wxBOTTOM, 15);
+
+    sizer->Add(dlg.CreateButtonSizer(wxOK), 0, wxEXPAND | wxBOTTOM, 10);
+
+    dlg.SetSizerAndFit(sizer);
+    dlg.Centre();
+    dlg.ShowModal();
 }

--- a/admin/src/MainFrame.h
+++ b/admin/src/MainFrame.h
@@ -30,6 +30,7 @@ public:
     ControlPanel* GetControlPanel() { return m_controlPanel; }
 
 private:
+    void OnSave(wxCommandEvent& event);
     void OnApply(wxCommandEvent& event);
     void OnRevert(wxCommandEvent& event);
     void OnExit(wxCommandEvent& event);
@@ -47,6 +48,7 @@ private:
     MimePanel* m_mimePanel;
     ControlPanel* m_controlPanel;
     
+    wxButton* m_saveBtn;
     wxButton* m_applyBtn;
     wxButton* m_revertBtn;
     
@@ -58,7 +60,8 @@ private:
 };
 
 enum {
-    ID_APPLY = wxID_HIGHEST + 1,
+    ID_SAVE = wxID_HIGHEST + 1,
+    ID_APPLY,
     ID_REVERT
 };
 

--- a/admin/src/MimePanel.cpp
+++ b/admin/src/MimePanel.cpp
@@ -53,6 +53,7 @@ MimePanel::MimePanel(wxWindow *parent, MainFrame *frame)
             wxALIGN_CENTER_VERTICAL);
   m_extCtrl = new wxTextCtrl(m_detailPanel, wxID_ANY, "", wxDefaultPosition,
                              wxSize(100, -1));
+  m_extCtrl->SetToolTip("File extension without leading dot (e.g. txt, html)");
   m_extCtrl->Bind(wxEVT_TEXT, &MimePanel::OnDetailChanged, this);
   grid->Add(m_extCtrl, 0);
 
@@ -61,6 +62,7 @@ MimePanel::MimePanel(wxWindow *parent, MainFrame *frame)
   m_typeCtrl = new wxTextCtrl(m_detailPanel, wxID_ANY, "", wxDefaultPosition,
                               wxDefaultSize);
   m_typeCtrl->SetMaxLength(3);
+  m_typeCtrl->SetToolTip("Three-digit hexadecimal RISC OS filetype (e.g. FFF for Text)");
   m_typeCtrl->Bind(wxEVT_TEXT, &MimePanel::OnDetailChanged, this);
   grid->Add(m_typeCtrl, 0);
 
@@ -163,16 +165,24 @@ void MimePanel::OnAddEntry(wxCommandEvent &event) {
 void MimePanel::OnRemoveEntry(wxCommandEvent &event) {
   wxUnusedVar(event);
 
-  if (m_currentIndex >= 0 &&
-      m_currentIndex < (int)m_frame->GetConfig().MimeMap().size()) {
-    m_frame->GetConfig().MimeMap().erase(
-        m_frame->GetConfig().MimeMap().begin() + m_currentIndex);
-    RefreshList();
-    m_currentIndex = -1;
-    m_detailPanel->Hide();
-    Layout();
-    m_frame->SetModified(true);
-  }
+  if (m_currentIndex < 0 ||
+      m_currentIndex >= (int)m_frame->GetConfig().MimeMap().size())
+    return;
+
+  const std::string& ext = m_frame->GetConfig().MimeMap()[m_currentIndex].ext;
+  int result = wxMessageBox(
+      wxString::Format("Remove mapping for '.%s'?", ext),
+      "Confirm Remove", wxYES_NO | wxICON_QUESTION, this);
+  if (result != wxYES)
+    return;
+
+  m_frame->GetConfig().MimeMap().erase(
+      m_frame->GetConfig().MimeMap().begin() + m_currentIndex);
+  RefreshList();
+  m_currentIndex = -1;
+  m_detailPanel->Hide();
+  Layout();
+  m_frame->SetModified(true);
 }
 
 void MimePanel::OnEntrySelected(wxListEvent &event) {
@@ -182,6 +192,35 @@ void MimePanel::OnEntrySelected(wxListEvent &event) {
 void MimePanel::OnDetailChanged(wxCommandEvent &event) {
   if (m_updating || m_currentIndex < 0)
     return;
+
+  // Sanitize extension: strip leading dot, lowercase, alphanumeric only
+  if (event.GetEventObject() == m_extCtrl) {
+    wxString val = m_extCtrl->GetValue();
+    wxString clean;
+    bool changed = false;
+    long pos = m_extCtrl->GetInsertionPoint();
+
+    for (wxString::iterator it = val.begin(); it != val.end(); ++it) {
+      wxChar c = *it;
+      if (c == '.' && clean.empty()) { changed = true; continue; } // strip leading dot
+      if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+        clean += c;
+      } else if (c >= 'A' && c <= 'Z') {
+        clean += wxTolower(c);
+        changed = true;
+      } else {
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      m_updating = true;
+      m_extCtrl->ChangeValue(clean);
+      if (pos > (long)clean.length()) pos = clean.length();
+      m_extCtrl->SetInsertionPoint(pos);
+      m_updating = false;
+    }
+  }
 
   // Validate/Sanitize Filetype (Hex only, Uppercase)
   if (event.GetEventObject() == m_typeCtrl) {

--- a/admin/src/PrintersPanel.cpp
+++ b/admin/src/PrintersPanel.cpp
@@ -2,6 +2,8 @@
 
 #include "PrintersPanel.h"
 #include "MainFrame.h"
+#include <wx/dirdlg.h>
+#include <wx/filedlg.h>
 
 enum {
   ID_ADD_PRINTER = wxID_HIGHEST + 200,
@@ -47,21 +49,47 @@ PrintersPanel::PrintersPanel(wxWindow *parent, MainFrame *frame)
   grid->Add(new wxStaticText(m_detailPanel, wxID_ANY, "Name:"), 0,
             wxALIGN_CENTER_VERTICAL);
   m_nameCtrl = new wxTextCtrl(m_detailPanel, wxID_ANY);
+  m_nameCtrl->SetToolTip("Printer name as seen by RISC OS clients");
   m_nameCtrl->Bind(wxEVT_TEXT, &PrintersPanel::OnDetailChanged, this);
   grid->Add(m_nameCtrl, 1, wxEXPAND);
 
   grid->Add(new wxStaticText(m_detailPanel, wxID_ANY, "Spool Path:"), 0,
             wxALIGN_CENTER_VERTICAL);
+  wxBoxSizer *pathSizer = new wxBoxSizer(wxHORIZONTAL);
   m_pathCtrl = new wxTextCtrl(m_detailPanel, wxID_ANY);
+  m_pathCtrl->SetToolTip("Directory where spooled print jobs are stored");
   m_pathCtrl->Bind(wxEVT_TEXT, &PrintersPanel::OnDetailChanged, this);
-  grid->Add(m_pathCtrl, 1, wxEXPAND);
+  pathSizer->Add(m_pathCtrl, 1, wxEXPAND);
+  wxButton *browsePathBtn = new wxButton(m_detailPanel, wxID_ANY, "Browse...");
+  browsePathBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) {
+    wxDirDialog dlg(this, "Select Printer Spool Directory",
+                    m_pathCtrl->GetValue(),
+                    wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+    if (dlg.ShowModal() == wxID_OK)
+      m_pathCtrl->SetValue(dlg.GetPath());
+  });
+  pathSizer->Add(browsePathBtn, 0, wxLEFT, 5);
+  grid->Add(pathSizer, 1, wxEXPAND);
 
   grid->Add(new wxStaticText(m_detailPanel, wxID_ANY, "Definition:"), 0,
             wxALIGN_CENTER_VERTICAL);
+  wxBoxSizer *defSizer = new wxBoxSizer(wxHORIZONTAL);
   m_definitionCtrl = new wxTextCtrl(m_detailPanel, wxID_ANY);
   m_definitionCtrl->SetHint("/path/to/printer.fc6");
+  m_definitionCtrl->SetToolTip("Path to the RISC OS printer definition (.fc6) file");
   m_definitionCtrl->Bind(wxEVT_TEXT, &PrintersPanel::OnDetailChanged, this);
-  grid->Add(m_definitionCtrl, 1, wxEXPAND);
+  defSizer->Add(m_definitionCtrl, 1, wxEXPAND);
+  wxButton *browseDefBtn = new wxButton(m_detailPanel, wxID_ANY, "Browse...");
+  browseDefBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) {
+    wxFileDialog dlg(this, "Select Printer Definition", "",
+                     m_definitionCtrl->GetValue(),
+                     "Printer definitions (*.fc6)|*.fc6|All files (*.*)|*.*",
+                     wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+    if (dlg.ShowModal() == wxID_OK)
+      m_definitionCtrl->SetValue(dlg.GetPath());
+  });
+  defSizer->Add(browseDefBtn, 0, wxLEFT, 5);
+  grid->Add(defSizer, 1, wxEXPAND);
 
   grid->Add(new wxStaticText(m_detailPanel, wxID_ANY, "Description:"), 0,
             wxALIGN_CENTER_VERTICAL);
@@ -84,6 +112,7 @@ PrintersPanel::PrintersPanel(wxWindow *parent, MainFrame *frame)
             wxALIGN_CENTER_VERTICAL);
   m_commandCtrl = new wxTextCtrl(m_detailPanel, wxID_ANY);
   m_commandCtrl->SetHint("lpr -P printer %f");
+  m_commandCtrl->SetToolTip("Shell command to print a file; %f is replaced with the spool file path");
   m_commandCtrl->Bind(wxEVT_TEXT, &PrintersPanel::OnDetailChanged, this);
   grid->Add(m_commandCtrl, 1, wxEXPAND);
 
@@ -183,16 +212,24 @@ void PrintersPanel::OnAddPrinter(wxCommandEvent &event) {
 void PrintersPanel::OnRemovePrinter(wxCommandEvent &event) {
   wxUnusedVar(event);
 
-  if (m_currentIndex >= 0 &&
-      m_currentIndex < (int)m_frame->GetConfig().Printers().size()) {
-    m_frame->GetConfig().Printers().erase(
-        m_frame->GetConfig().Printers().begin() + m_currentIndex);
-    RefreshList();
-    m_currentIndex = -1;
-    m_detailPanel->Hide();
-    Layout();
-    m_frame->SetModified(true);
-  }
+  if (m_currentIndex < 0 ||
+      m_currentIndex >= (int)m_frame->GetConfig().Printers().size())
+    return;
+
+  const std::string& name = m_frame->GetConfig().Printers()[m_currentIndex].name;
+  int result = wxMessageBox(
+      wxString::Format("Remove printer '%s'?", name),
+      "Confirm Remove", wxYES_NO | wxICON_QUESTION, this);
+  if (result != wxYES)
+    return;
+
+  m_frame->GetConfig().Printers().erase(
+      m_frame->GetConfig().Printers().begin() + m_currentIndex);
+  RefreshList();
+  m_currentIndex = -1;
+  m_detailPanel->Hide();
+  Layout();
+  m_frame->SetModified(true);
 }
 
 void PrintersPanel::OnPrinterSelected(wxListEvent &event) {

--- a/admin/src/SharesPanel.cpp
+++ b/admin/src/SharesPanel.cpp
@@ -55,6 +55,7 @@ SharesPanel::SharesPanel(wxWindow *parent, MainFrame *frame)
                        wxSize(labelWidth, -1));
   row1->Add(labelName, 0, wxALIGN_CENTER_VERTICAL);
   m_nameCtrl = new wxTextCtrl(m_detailPanel, wxID_ANY);
+  m_nameCtrl->SetToolTip("Share name as seen by RISC OS clients (no spaces)");
   m_nameCtrl->Bind(wxEVT_TEXT, &SharesPanel::OnDetailChanged, this);
   row1->Add(m_nameCtrl, 1, wxEXPAND);
   formSizer->Add(row1, 0, wxEXPAND | wxBOTTOM, 8);
@@ -66,6 +67,7 @@ SharesPanel::SharesPanel(wxWindow *parent, MainFrame *frame)
                        wxSize(labelWidth, -1));
   row2->Add(labelPath, 0, wxALIGN_CENTER_VERTICAL);
   m_pathCtrl = new wxTextCtrl(m_detailPanel, wxID_ANY);
+  m_pathCtrl->SetToolTip("Absolute path on this server to share with clients");
   m_pathCtrl->Bind(wxEVT_TEXT, &SharesPanel::OnDetailChanged, this);
   row2->Add(m_pathCtrl, 1, wxEXPAND);
   wxButton *browseBtn =
@@ -82,6 +84,7 @@ SharesPanel::SharesPanel(wxWindow *parent, MainFrame *frame)
   m_passwordCtrl =
       new wxTextCtrl(m_detailPanel, wxID_ANY, "", wxDefaultPosition,
                      wxDefaultSize, wxTE_PASSWORD);
+  m_passwordCtrl->SetToolTip("Optional password required to access this share");
   m_passwordCtrl->Bind(wxEVT_TEXT, &SharesPanel::OnDetailChanged, this);
   row3->Add(m_passwordCtrl, 1, wxEXPAND);
   formSizer->Add(row3, 0, wxEXPAND | wxBOTTOM, 8);
@@ -116,6 +119,11 @@ SharesPanel::SharesPanel(wxWindow *parent, MainFrame *frame)
   m_attrHidden = new wxCheckBox(m_detailPanel, wxID_ANY, "Hidden from browser");
   m_attrHidden->Bind(wxEVT_CHECKBOX, &SharesPanel::OnAttrChanged, this);
   attrBox->Add(m_attrHidden, 0, wxALL, 5);
+
+  m_attrSubdir = new wxCheckBox(m_detailPanel, wxID_ANY, "Subdirectory share");
+  m_attrSubdir->SetToolTip("Share represents a subdirectory of the host path");
+  m_attrSubdir->Bind(wxEVT_CHECKBOX, &SharesPanel::OnAttrChanged, this);
+  attrBox->Add(m_attrSubdir, 0, wxALL, 5);
 
   m_attrCdrom = new wxCheckBox(m_detailPanel, wxID_ANY, "CD-ROM share");
   m_attrCdrom->Bind(wxEVT_CHECKBOX, &SharesPanel::OnAttrChanged, this);
@@ -170,6 +178,7 @@ void SharesPanel::ShowDetails(int index) {
   m_attrProtected->SetValue(share.attributes & RAS_ATTR_PROTECTED);
   m_attrReadonly->SetValue(share.attributes & RAS_ATTR_READONLY);
   m_attrHidden->SetValue(share.attributes & RAS_ATTR_HIDDEN);
+  m_attrSubdir->SetValue(share.attributes & RAS_ATTR_SUBDIR);
   m_attrCdrom->SetValue(share.attributes & RAS_ATTR_CDROM);
 
   m_detailPanel->Show();
@@ -184,7 +193,9 @@ void SharesPanel::SaveCurrentDetails() {
     return;
 
   ShareConfig &share = m_frame->GetConfig().Shares()[m_currentIndex];
-  share.name = m_nameCtrl->GetValue().ToStdString();
+  std::string newName = m_nameCtrl->GetValue().ToStdString();
+  if (newName.empty()) newName = share.name; // don't save blank name
+  share.name = newName;
   share.path = m_pathCtrl->GetValue().ToStdString();
   share.password = m_passwordCtrl->GetValue().ToStdString();
   share.default_type = m_defaultTypeCtrl->GetValue().ToStdString();
@@ -196,6 +207,8 @@ void SharesPanel::SaveCurrentDetails() {
     share.attributes |= RAS_ATTR_READONLY;
   if (m_attrHidden->GetValue())
     share.attributes |= RAS_ATTR_HIDDEN;
+  if (m_attrSubdir->GetValue())
+    share.attributes |= RAS_ATTR_SUBDIR;
   if (m_attrCdrom->GetValue())
     share.attributes |= RAS_ATTR_CDROM;
 
@@ -221,16 +234,24 @@ void SharesPanel::OnAddShare(wxCommandEvent &event) {
 void SharesPanel::OnRemoveShare(wxCommandEvent &event) {
   wxUnusedVar(event);
 
-  if (m_currentIndex >= 0 &&
-      m_currentIndex < (int)m_frame->GetConfig().Shares().size()) {
-    m_frame->GetConfig().Shares().erase(m_frame->GetConfig().Shares().begin() +
-                                        m_currentIndex);
-    RefreshList();
-    m_currentIndex = -1;
-    m_detailPanel->Hide();
-    Layout();
-    m_frame->SetModified(true);
-  }
+  if (m_currentIndex < 0 ||
+      m_currentIndex >= (int)m_frame->GetConfig().Shares().size())
+    return;
+
+  const std::string& name = m_frame->GetConfig().Shares()[m_currentIndex].name;
+  int result = wxMessageBox(
+      wxString::Format("Remove share '%s'?", name),
+      "Confirm Remove", wxYES_NO | wxICON_QUESTION, this);
+  if (result != wxYES)
+    return;
+
+  m_frame->GetConfig().Shares().erase(m_frame->GetConfig().Shares().begin() +
+                                      m_currentIndex);
+  RefreshList();
+  m_currentIndex = -1;
+  m_detailPanel->Hide();
+  Layout();
+  m_frame->SetModified(true);
 }
 
 void SharesPanel::OnShareSelected(wxListEvent &event) {

--- a/admin/src/SharesPanel.h
+++ b/admin/src/SharesPanel.h
@@ -38,6 +38,7 @@ private:
     wxCheckBox* m_attrProtected;
     wxCheckBox* m_attrReadonly;
     wxCheckBox* m_attrHidden;
+    wxCheckBox* m_attrSubdir;
     wxCheckBox* m_attrCdrom;
     
     int m_currentIndex = -1;

--- a/admin/src/main.cpp
+++ b/admin/src/main.cpp
@@ -19,15 +19,29 @@ public:
       frame->LoadConfig(argv[1].ToStdString());
     } else {
 #ifdef __WXMSW__
-      // Windows: check default install dir, then current directory
-      if (wxFileExists("C:/AccessServer/access.conf")) {
+      // Windows: %ProgramData%\AccessServer, then legacy C:\AccessServer, then CWD
+      wxString progData;
+      if (!wxGetEnv("ProgramData", &progData) || progData.empty())
+        progData = "C:";
+      wxString pdPath = progData + "\\AccessServer\\access.conf";
+      if (wxFileExists(pdPath)) {
+        frame->LoadConfig(pdPath.ToStdString());
+      } else if (wxFileExists("C:/AccessServer/access.conf")) {
         frame->LoadConfig("C:/AccessServer/access.conf");
       } else if (wxFileExists("access.conf")) {
         frame->LoadConfig("access.conf");
       }
 #else
-      // Linux: check /etc/access.conf then current directory
-      if (wxFileExists("/etc/access.conf")) {
+      // Linux: XDG_CONFIG_HOME, ~/.config, /etc/riscos-access-server, /etc, CWD
+      wxString xdgConfigHome;
+      if (!wxGetEnv("XDG_CONFIG_HOME", &xdgConfigHome) || xdgConfigHome.empty())
+        xdgConfigHome = wxGetHomeDir() + "/.config";
+      wxString xdgPath = xdgConfigHome + "/riscos-access-server/access.conf";
+      if (wxFileExists(xdgPath)) {
+        frame->LoadConfig(xdgPath.ToStdString());
+      } else if (wxFileExists("/etc/riscos-access-server/access.conf")) {
+        frame->LoadConfig("/etc/riscos-access-server/access.conf");
+      } else if (wxFileExists("/etc/access.conf")) {
         frame->LoadConfig("/etc/access.conf");
       } else if (wxFileExists("access.conf")) {
         frame->LoadConfig("access.conf");


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR addresses all issues found during a full codebase review, split across two areas:

### Server-side fixes (`src/`)

- **Per-client handle security**: file/directory handles are now bound to the client IP:port that opened them; cross-client handle reuse is rejected (`handle.c/h`, `ops.c`)
- **Pending read timeout**: stale pending reads expire after 30 s to prevent memory accumulation (`ops.c`)
- **Path encoding buffer overflow**: `build_host_path_from_ro` now uses a correctly-sized `3×segment` buffer (`ops.c`)
- **Shell injection in printer commands**: `shell_quote()` wraps the spool-file path in single quotes before substitution into the print command (`printer.c`)
- **RSETINFO rename error handling**: rename failures are now tracked and reported back to the client (`ops.c`)

### Admin UI improvements (`admin/src/`)

**Bug fixes / correctness**
- `std::stoi()` calls for `broadcast_interval` and `poll_interval` are now wrapped in try/catch — previously crashed on a malformed config
- `RAS_ATTR_SUBDIR` (0x08) was silently dropped on every config save; now round-trips correctly through `AttrsToString`/`StringToAttrs` and a new UI checkbox
- Config saves are now **atomic**: write to `.tmp`, flush + error-check, then rename — prevents data loss if the process dies mid-write

**Config path discovery**
- Linux: searches `$XDG_CONFIG_HOME/riscos-access-server/`, `~/.config/riscos-access-server/`, `/etc/riscos-access-server/`, then `/etc/` (legacy)
- Windows: checks `%ProgramData%\AccessServer\` before the legacy `C:\AccessServer\` fallback

**MainFrame**
- New **Save** action (Ctrl+S): saves config without restarting the server
- **Apply && Restart** is now a distinct action (Ctrl+Shift+R)
- About dialog uses `wxHyperlinkCtrl` so the GPL licence URL is clickable

**SharesPanel**
- New **Subdirectory share** checkbox exposes `RAS_ATTR_SUBDIR`
- Confirmation dialog before removing a share
- Tooltips on all fields; blank share name is not saved

**PrintersPanel**
- **Browse…** buttons for Spool Path (directory picker) and Definition (`.fc6` file picker)
- Confirmation dialog before removing a printer
- Tooltips on all fields

**MimePanel**
- Confirmation dialog before removing a MIME entry
- Extension field sanitises input on-the-fly: strips leading dot, lowercases, rejects non-alphanumeric
- Tooltips on extension and filetype fields

**ControlPanel**
- Log view truncates to newest 4,000 lines when it exceeds 5,000 (prevents unbounded growth)
- Binary search for server binary now checks `/usr/local/bin/access` and `/usr/bin/access` on Linux
- Default config path uses `%ProgramData%` on Windows, `/etc/riscos-access-server/` on Linux
- Windows service poll loops call `wxSafeYield()` each iteration — UI stays responsive during start/stop
- systemd restart no longer blocks the UI thread with `wxMilliSleep(1000)`
- Warning logged when `pkexec` is attempted without `DISPLAY`/`WAYLAND_DISPLAY` set

## Test plan

- [ ] Build server (`cmake .. -DRAS_BUILD_ADMIN=OFF && make`) — no new warnings
- [ ] Attempt to access a handle from a different client IP — should be rejected
- [ ] Set `broadcast_interval = not_a_number` in config — admin should load without crashing
- [ ] Save config via admin, kill process mid-write — original file should be intact
- [ ] Add a share with SUBDIR attribute, save, reload — attribute should be preserved
- [ ] Confirm all three confirmation dialogs appear before remove operations
- [ ] Verify Browse buttons open correct pickers (directory vs .fc6 file)
- [ ] On Linux: confirm `/usr/local/bin/access` or `/usr/bin/access` is found when present
- [ ] Verify Ctrl+S saves without restarting; Apply && Restart does both

https://claude.ai/code/session_01NX67oPbax4Yiirt11pu7AZ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX67oPbax4Yiirt11pu7AZ)_